### PR TITLE
fix: sts2 set expired time unit seconds instead of millisecond.

### DIFF
--- a/src/main/java/com/bytedanceapi/service/BaseServiceImpl.java
+++ b/src/main/java/com/bytedanceapi/service/BaseServiceImpl.java
@@ -395,7 +395,7 @@ public abstract class BaseServiceImpl implements IBaseService {
         sts2.setCurrentTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").format(now));
         sts2.setExpiredTime(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").format(expireTime));
 
-        InnerToken innerToken = Sts2Utils.createInnerToken(serviceInfo.getCredentials(),sts2,inlinePolicy,expireTime.getTime());
+        InnerToken innerToken = Sts2Utils.createInnerToken(serviceInfo.getCredentials(),sts2,inlinePolicy,expireTime.getTime()/1000);
         String sessionToken = "STS2" + Base64.getEncoder().encodeToString(JSON.toJSONString(innerToken).getBytes());
         sts2.setSessionToken(sessionToken);
         return sts2;


### PR DESCRIPTION
STS2 的过期时间设置单位为秒而不是毫秒，修复bug。